### PR TITLE
增加rabbitmq的支持，并添加RABBITMQ_MANAGER 在15267 端口

### DIFF
--- a/.env
+++ b/.env
@@ -6,9 +6,9 @@ NETWORKS_DRIVER=bridge
 
 # PATHS ##########################################
 # 宿主机上代码存放的目录路径
-CODE_PATH_HOST=./code
+CODE_PATH_HOST=/Users/xiaoheihe/codes
 # 宿主机上Mysql Reids数据存放的目录路径
-DATA_PATH_HOST=./data
+DATA_PATH_HOST=/Users/xiaoheihe/datas
 
 
 # MYSQL ##########################################

--- a/.env
+++ b/.env
@@ -34,7 +34,7 @@ MYSQL_MANAGE_PORT=1000
 
 # REDIS ##########################################
 # Redis 服务映射宿主机端口号，可在宿主机127.0.0.1:6379访问
-REDIS_PORT=6379
+REDIS_PORT=55000
 
 # Redis 可视化管理用户名称
 REDIS_MANAGE_USERNAME=admin

--- a/.env
+++ b/.env
@@ -74,3 +74,9 @@ JAEGER_PORT=5000
 DTM_HTTP_PORT=36789
 # DTM gRPC 协议端口号
 DTM_GRPC_PORT=36790
+
+# RabbitMQ #################################
+# RabbitMQ 端口
+RABBITMQ_PORT=5267
+# RabbitMQ Manager 端口
+RABBITMQ_MANAGER_PORT=15267

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ code
 data
 logs
 node_modules
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,4 +192,29 @@ services:
       - "${RABBITMQ_MANAGER_PORT}:15672"
     networks:
       - backend
-    restart: always
+    # restart: always
+
+  zookeeper:
+    image: 'bitnami/zookeeper:latest'
+    ports:
+      - '2181:2181'
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    networks:
+      - backend
+  
+  kafka:
+    image: 'bitnami/kafka:latest'
+    ports:
+      - '9092:9092'
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_NUM_PARTITIONS=10
+    depends_on:
+      - zookeeper
+    networks:
+      - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,18 +109,18 @@ services:
       - backend
     restart: always
 
-  etcd-manage:
-    build:
-      context: ./etcd-manage
-    environment:
-      - TZ=${TZ}
-    ports:
-      - "${ETCD_MANAGE_PORT}:8080"                    # 设置容器8080端口映射指定宿主机端口，用于宿主机访问可视化web
-    depends_on:                                       # 依赖容器
-      - etcd                                          # 在 etcd 服务容器启动后启动
-    networks:
-      - backend
-    restart: always
+  # etcd-manage:
+  #   build:
+  #     context: ./etcd-manage
+  #   environment:
+  #     - TZ=${TZ}
+  #   ports:
+  #     - "${ETCD_MANAGE_PORT}:8080"                    # 设置容器8080端口映射指定宿主机端口，用于宿主机访问可视化web
+  #   depends_on:                                       # 依赖容器
+  #     - etcd                                          # 在 etcd 服务容器启动后启动
+  #   networks:
+  #     - backend
+  #   restart: always
 
   prometheus:
     build:
@@ -158,40 +158,40 @@ services:
       - backend
     restart: always
 
-  dtm:
-    build:
-      context: ./dtm
-    environment:
-      - TZ=${TZ}
-    entrypoint:
-      - "/app/dtm/dtm"
-      - "-c=/app/dtm/configs/config.yaml"
-    privileged: true
-    volumes:
-      - ./dtm/config.yml:/app/dtm/configs/config.yaml # 将 dtm 配置文件挂载到容器里
-    ports:
-      - "${DTM_HTTP_PORT}:36789"
-      - "${DTM_GRPC_PORT}:36790"
-    networks:
-      - backend
-    restart: always
+  # dtm:
+  #   build:
+  #     context: ./dtm
+  #   environment:
+  #     - TZ=${TZ}
+  #   entrypoint:
+  #     - "/app/dtm/dtm"
+  #     - "-c=/app/dtm/configs/config.yaml"
+  #   privileged: true
+  #   volumes:
+  #     - ./dtm/config.yml:/app/dtm/configs/config.yaml # 将 dtm 配置文件挂载到容器里
+  #   ports:
+  #     - "${DTM_HTTP_PORT}:36789"
+  #     - "${DTM_GRPC_PORT}:36790"
+  #   networks:
+  #     - backend
+  #   restart: always
 
-  rabbitmq:
-    build:
-      context: ./rabbitmq
-    container_name: rabbitMq
-    environment:
-      - TZ=${TZ}
-      - RABBITMQ_DEFAULT_USER=admin                         #rabbitmq 的默认账号
-      - RABBITMQ_DEFAULT_PASS=123456                        #rabbitmq 的默认密码
-    volumes:
-      - ${DATA_PATH_HOST}/rabbitmq/data:/var/lib/rabbitmq   #数据文件挂载
-      - ${DATA_PATH_HOST}/rabbitmq/log:/var/log/rabbitmq    #日志文件挂载
-    ports:
-      - "${RABBITMQ_PORT}:5672"
-      - "${RABBITMQ_MANAGER_PORT}:15672"
-    networks:
-      - backend
+  # rabbitmq:
+  #   build:
+  #     context: ./rabbitmq
+  #   container_name: rabbitMq
+  #   environment:
+  #     - TZ=${TZ}
+  #     - RABBITMQ_DEFAULT_USER=admin                         #rabbitmq 的默认账号
+  #     - RABBITMQ_DEFAULT_PASS=123456                        #rabbitmq 的默认密码
+  #   volumes:
+  #     - ${DATA_PATH_HOST}/rabbitmq/data:/var/lib/rabbitmq   #数据文件挂载
+  #     - ${DATA_PATH_HOST}/rabbitmq/log:/var/log/rabbitmq    #日志文件挂载
+  #   ports:
+  #     - "${RABBITMQ_PORT}:5672"
+  #     - "${RABBITMQ_MANAGER_PORT}:15672"
+  #   networks:
+  #     - backend
     # restart: always
 
   zookeeper:
@@ -199,15 +199,19 @@ services:
     ports:
       - '2181:2181'
     environment:
+      - TZ=${TZ}
       - ALLOW_ANONYMOUS_LOGIN=yes
     networks:
       - backend
+    volumes:
+      - ${DATA_PATH_HOST}/zookeeper:/bitnami/zookeeper
   
   kafka:
     image: 'bitnami/kafka:latest'
     ports:
       - '9092:9092'
     environment:
+      - TZ=${TZ}
       - KAFKA_BROKER_ID=1
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
@@ -218,3 +222,16 @@ services:
       - zookeeper
     networks:
       - backend
+    volumes:
+      - ${DATA_PATH_HOST}/kafka:/bitnami/kafka
+
+  postgres:
+    image: postgres:latest
+    environment:
+      - POSTGRES_PASSWORD=postgrespw
+    ports:
+      - 55001:5432
+    networks:
+      - backend
+    volumes:
+      - ${DATA_PATH_HOST}/postgresql:/var/lib/postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,3 +175,21 @@ services:
     networks:
       - backend
     restart: always
+
+  rabbitmq:
+    build:
+      context: ./rabbitmq
+    container_name: rabbitMq
+    environment:
+      - TZ=${TZ}
+      - RABBITMQ_DEFAULT_USER=admin                         #rabbitmq 的默认账号
+      - RABBITMQ_DEFAULT_PASS=123456                        #rabbitmq 的默认密码
+    volumes:
+      - ${DATA_PATH_HOST}/rabbitmq/data:/var/lib/rabbitmq   #数据文件挂载
+      - ${DATA_PATH_HOST}/rabbitmq/log:/var/log/rabbitmq    #日志文件挂载
+    ports:
+      - "${RABBITMQ_PORT}:5672"
+      - "${RABBITMQ_MANAGER_PORT}:15672"
+    networks:
+      - backend
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,3 +235,12 @@ services:
       - backend
     volumes:
       - ${DATA_PATH_HOST}/postgresql:/var/lib/postgresql
+
+  nginx:
+    image: nginx
+    ports:
+      - "10000:80"
+    volumes:
+      - ${DATA_PATH_HOST}/nginx:/usr/nginx
+    environment:
+      - TZ=${TZ}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,50 @@
 version: '3.5'
 # 网络配置
+
 networks:
   backend:
     driver: ${NETWORKS_DRIVER}
 
 # 服务容器配置
 services:
-  golang:                                # 自定义容器名称
+  golang:
+    # 自定义容器名称
     build:
-      context: ./golang                  # 指定构建使用的 Dockerfile 文件
-    environment:                         # 设置环境变量
+      context: ./golang # 指定构建使用的 Dockerfile 文件
+    environment:
+      # 设置环境变量
       - TZ=${TZ}
     privileged: true
-    volumes:                             # 设置挂载目录
-      - ${CODE_PATH_HOST}:/usr/src/code  # 引用 .env 配置中 CODE_PATH_HOST 变量，将宿主机上代码存放的目录挂载到容器中 /usr/src/code 目录
-    ports:                               # 设置端口映射
-      - "8000:8000"
-      - "8001:8001"
-      - "8002:8002"
-      - "8003:8003"
-      - "9000:9000"
-      - "9001:9001"
-      - "9002:9002"
-      - "9003:9003"
-    stdin_open: true                     # 打开标准输入，可以接受外部输入
+    volumes:
+      # 设置挂载目录
+      - ${CODE_PATH_HOST}:/usr/src/code # 引用 .env 配置中 CODE_PATH_HOST 变量，将宿主机上代码存放的目录挂载到容器中 /usr/src/code 目录
+    ports:
+      # 设置端口映射
+      # - "8000:8000"
+      # - "8001:8001"
+      # - "8002:8002"
+      # - "8003:8003"
+      # - "9000:9000"
+      # - "9001:9001"
+      # - "9002:9002"
+      # - "9003:9003"
+      - '8000:22'
+    stdin_open: true # 打开标准输入，可以接受外部输入
     tty: true
     networks:
       - backend
-    restart: always                      # 指定容器退出后的重启策略为始终重启
+    restart: always # 指定容器退出后的重启策略为始终重启
 
-  etcd:                                  # 自定义容器名称
+  etcd:
+    # 自定义容器名称
     build:
-      context: ./etcd                    # 指定构建使用的 Dockerfile 文件
+      context: ./etcd # 指定构建使用的 Dockerfile 文件
     environment:
       - TZ=${TZ}
       - ALLOW_NONE_AUTHENTICATION=yes
       - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
-    ports:                               # 设置端口映射
+    ports:
+      # 设置端口映射
       - "${ETCD_PORT}:2379"
     networks:
       - backend
@@ -47,14 +55,14 @@ services:
       context: ./mysql
     environment:
       - TZ=${TZ}
-      - MYSQL_USER=${MYSQL_USERNAME}                  # 设置 Mysql 用户名称
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD}              # 设置 Mysql 用户密码
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}    # 设置 Mysql root 用户密码
+      - MYSQL_USER=${MYSQL_USERNAME} # 设置 Mysql 用户名称
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD} # 设置 Mysql 用户密码
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD} # 设置 Mysql root 用户密码
     privileged: true
     volumes:
-      - ${DATA_PATH_HOST}/mysql:/var/lib/mysql        # 引用 .env 配置中 DATA_PATH_HOST 变量，将宿主机上存放 Mysql 数据的目录挂载到容器中 /var/lib/mysql 目录
+      - ${DATA_PATH_HOST}/mysql:/var/lib/mysql # 引用 .env 配置中 DATA_PATH_HOST 变量，将宿主机上存放 Mysql 数据的目录挂载到容器中 /var/lib/mysql 目录
     ports:
-      - "${MYSQL_PORT}:3306"                          # 设置容器3306端口映射指定宿主机端口
+      - "${MYSQL_PORT}:3306" # 设置容器3306端口映射指定宿主机端口
     networks:
       - backend
     restart: always
@@ -66,9 +74,9 @@ services:
       - TZ=${TZ}
     privileged: true
     volumes:
-      - ${DATA_PATH_HOST}/redis:/data                 # 引用 .env 配置中 DATA_PATH_HOST 变量，将宿主机上存放 Redis 数据的目录挂载到容器中 /data 目录
+      - ${DATA_PATH_HOST}/redis:/data # 引用 .env 配置中 DATA_PATH_HOST 变量，将宿主机上存放 Redis 数据的目录挂载到容器中 /data 目录
     ports:
-      - "${REDIS_PORT}:6379"                          # 设置容器6379端口映射指定宿主机端口
+      - "${REDIS_PORT}:6379" # 设置容器6379端口映射指定宿主机端口
     networks:
       - backend
     restart: always
@@ -79,15 +87,16 @@ services:
     environment:
       - TZ=${TZ}
       - PMA_ARBITRARY=1
-      - MYSQL_USER=${MYSQL_MANAGE_USERNAME}               # 设置连接的 Mysql 服务用户名称
-      - MYSQL_PASSWORD=${MYSQL_MANAGE_PASSWORD}           # 设置连接的 Mysql 服务用户密码
+      - MYSQL_USER=${MYSQL_MANAGE_USERNAME} # 设置连接的 Mysql 服务用户名称
+      - MYSQL_PASSWORD=${MYSQL_MANAGE_PASSWORD} # 设置连接的 Mysql 服务用户密码
       - MYSQL_ROOT_PASSWORD=${MYSQL_MANAGE_ROOT_PASSWORD} # 设置连接的 Mysql 服务 root 用户密码
-      - PMA_HOST=${MYSQL_MANAGE_CONNECT_HOST}             # 设置连接的 Mysql 服务 host，可以是 Mysql 服务容器的名称，也可以是 Mysql 服务容器的 ip 地址
-      - PMA_PORT=${MYSQL_MANAGE_CONNECT_PORT}             # 设置连接的 Mysql 服务端口号
+      - PMA_HOST=${MYSQL_MANAGE_CONNECT_HOST} # 设置连接的 Mysql 服务 host，可以是 Mysql 服务容器的名称，也可以是 Mysql 服务容器的 ip 地址
+      - PMA_PORT=${MYSQL_MANAGE_CONNECT_PORT} # 设置连接的 Mysql 服务端口号
     ports:
-      - "${MYSQL_MANAGE_PORT}:80"                         # 设置容器80端口映射指定宿主机端口，用于宿主机访问可视化web
-    depends_on:                                           # 依赖容器
-      - mysql                                             # 在 Mysql 服务容器启动后启动
+      - "${MYSQL_MANAGE_PORT}:80" # 设置容器80端口映射指定宿主机端口，用于宿主机访问可视化web
+    depends_on:
+      # 依赖容器
+      - mysql # 在 Mysql 服务容器启动后启动
     networks:
       - backend
     restart: always
@@ -97,14 +106,15 @@ services:
       context: ./redis-manage
     environment:
       - TZ=${TZ}
-      - ADMIN_USER=${REDIS_MANAGE_USERNAME}           # 设置 Redis 可视化管理的用户名称
-      - ADMIN_PASS=${REDIS_MANAGE_PASSWORD}           # 设置 Redis 可视化管理的用户密码
-      - REDIS_1_HOST=${REDIS_MANAGE_CONNECT_HOST}     # 设置连接的 Redis 服务 host，可以是 Redis 服务容器的名称，也可以是 Redis 服务容器的 ip 地址
-      - REDIS_1_PORT=${REDIS_MANAGE_CONNECT_PORT}     # 设置连接的 Redis 服务端口号
+      - ADMIN_USER=${REDIS_MANAGE_USERNAME} # 设置 Redis 可视化管理的用户名称
+      - ADMIN_PASS=${REDIS_MANAGE_PASSWORD} # 设置 Redis 可视化管理的用户密码
+      - REDIS_1_HOST=${REDIS_MANAGE_CONNECT_HOST} # 设置连接的 Redis 服务 host，可以是 Redis 服务容器的名称，也可以是 Redis 服务容器的 ip 地址
+      - REDIS_1_PORT=${REDIS_MANAGE_CONNECT_PORT} # 设置连接的 Redis 服务端口号
     ports:
-      - "${REDIS_MANAGE_PORT}:80"                     # 设置容器80端口映射指定宿主机端口，用于宿主机访问可视化web
-    depends_on:                                       # 依赖容器
-      - redis                                         # 在 Redis 服务容器启动后启动
+      - "${REDIS_MANAGE_PORT}:80" # 设置容器80端口映射指定宿主机端口，用于宿主机访问可视化web
+    depends_on:
+      # 依赖容器
+      - redis # 在 Redis 服务容器启动后启动
     networks:
       - backend
     restart: always
@@ -129,9 +139,9 @@ services:
       - TZ=${TZ}
     privileged: true
     volumes:
-      - ./prometheus/prometheus.yml:/opt/bitnami/prometheus/conf/prometheus.yml  # 将 prometheus 配置文件挂载到容器里
+      - ./prometheus/prometheus.yml:/opt/bitnami/prometheus/conf/prometheus.yml # 将 prometheus 配置文件挂载到容器里
     ports:
-      - "${PROMETHEUS_PORT}:9090"                     # 设置容器9090端口映射指定宿主机端口，用于宿主机访问可视化web
+      - "${PROMETHEUS_PORT}:9090" # 设置容器9090端口映射指定宿主机端口，用于宿主机访问可视化web
     networks:
       - backend
     restart: always
@@ -142,7 +152,7 @@ services:
     environment:
       - TZ=${TZ}
     ports:
-      - "${GRAFANA_PORT}:3000"                        # 设置容器3000端口映射指定宿主机端口，用于宿主机访问可视化web
+      - "${GRAFANA_PORT}:3000" # 设置容器3000端口映射指定宿主机端口，用于宿主机访问可视化web
     networks:
       - backend
     restart: always
@@ -153,28 +163,27 @@ services:
     environment:
       - TZ=${TZ}
     ports:
-      - "${JAEGER_PORT}:16686"                        # 设置容器16686端口映射指定宿主机端口，用于宿主机访问可视化web
+      - "${JAEGER_PORT}:16686" # 设置容器16686端口映射指定宿主机端口，用于宿主机访问可视化web
     networks:
       - backend
     restart: always
-
-  # dtm:
-  #   build:
-  #     context: ./dtm
-  #   environment:
-  #     - TZ=${TZ}
-  #   entrypoint:
-  #     - "/app/dtm/dtm"
-  #     - "-c=/app/dtm/configs/config.yaml"
-  #   privileged: true
-  #   volumes:
-  #     - ./dtm/config.yml:/app/dtm/configs/config.yaml # 将 dtm 配置文件挂载到容器里
-  #   ports:
-  #     - "${DTM_HTTP_PORT}:36789"
-  #     - "${DTM_GRPC_PORT}:36790"
-  #   networks:
-  #     - backend
-  #   restart: always
+  dtm:
+    build:
+      context: ./dtm
+    environment:
+      - TZ=${TZ}
+    entrypoint:
+      - "/app/dtm/dtm"
+      - "-c=/app/dtm/configs/config.yaml"
+    privileged: true
+    volumes:
+      - ./dtm/config.yml:/app/dtm/configs/config.yaml # 将 dtm 配置文件挂载到容器里
+    ports:
+      - "${DTM_HTTP_PORT}:36789"
+      - "${DTM_GRPC_PORT}:36790"
+    networks:
+      - backend
+    restart: always
 
   # rabbitmq:
   #   build:
@@ -192,7 +201,7 @@ services:
   #     - "${RABBITMQ_MANAGER_PORT}:15672"
   #   networks:
   #     - backend
-    # restart: always
+  #   restart: always
 
   zookeeper:
     image: 'bitnami/zookeeper:latest'
@@ -205,7 +214,7 @@ services:
       - backend
     volumes:
       - ${DATA_PATH_HOST}/zookeeper:/bitnami/zookeeper
-  
+
   kafka:
     image: 'bitnami/kafka:latest'
     ports:
@@ -236,11 +245,54 @@ services:
     volumes:
       - ${DATA_PATH_HOST}/postgresql:/var/lib/postgresql
 
-  nginx:
-    image: nginx
+  # nginx:
+  #   image: nginx
+  #   ports:
+  #     - "10000:80"
+  #   volumes:
+  #     - ${DATA_PATH_HOST}/nginx:/usr/nginx
+  #   environment:
+  #     - TZ=${TZ}
+
+  mongo:
+    image: mongo
     ports:
-      - "10000:80"
-    volumes:
-      - ${DATA_PATH_HOST}/nginx:/usr/nginx
+      - 55002:27017
+    # restart: always
     environment:
       - TZ=${TZ}
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=123456
+    volumes:
+      - ${DATA_PATH_HOST}/mongo:/data/db
+    networks:
+      - backend
+  mongo-express:
+    image: mongo-express
+    ports:
+      - 55003:8081
+    networks:
+      - backend
+    environment:
+      - TZ=${TZ}
+      - ME_CONFIG_MONGODB_ADMINUSERNAME=admin
+      - ME_CONFIG_MONGODB_ADMINPASSWORD=123456
+      - ME_CONFIG_MONGODB_URL=mongodb://admin:123456@mongo:27017/
+    depends_on:
+      - mongo
+  # rocketmq:
+  #   build:
+  #     context: ./rocketmq-console
+  #   container_name: rocketmq-console
+  #   networks:
+  #     - backend
+  #   ports:
+  #     - 10909:10909
+  #     - 10911:10911
+  #     - 10912:10912
+  #     - 9876:9876
+  #     - 8080:8080
+  #   environment:
+  #     - TZ=${TZ}
+    # volumes:
+      # - ${DATA_PATH_HOST}/rocketmq-console:/home/app/rocketmq

--- a/dtm/Dockerfile
+++ b/dtm/Dockerfile
@@ -1,3 +1,1 @@
 FROM yedf/dtm
-
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/etcd-manage/Dockerfile
+++ b/etcd-manage/Dockerfile
@@ -1,3 +1,1 @@
 FROM evildecay/etcdkeeper
-
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -1,3 +1,1 @@
 FROM bitnami/etcd
-
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get clean && \
 # 设置工作目录
 WORKDIR /usr/src/code
 
+EXPOSE 22
 EXPOSE 8000
 EXPOSE 8001
 EXPOSE 8002

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,3 +1,1 @@
 FROM grafana/grafana
-
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/jaeger/Dockerfile
+++ b/jaeger/Dockerfile
@@ -1,3 +1,1 @@
 FROM jaegertracing/all-in-one:1.28
-
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/mysql-manage/Dockerfile
+++ b/mysql-manage/Dockerfile
@@ -1,3 +1,1 @@
 FROM phpmyadmin/phpmyadmin
-
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,3 +1,1 @@
 FROM mysql:5.7
-
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/nginx/dockerfile
+++ b/nginx/dockerfile
@@ -1,0 +1,1 @@
+FROM nginx

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,38 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    location /gozero/ {
+        proxy_pass localhost:8888/;
+    }
+    location /gin/ {
+        proxy_pass localhost:8889/;
+    }
+}

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,3 +1,2 @@
 FROM bitnami/prometheus
 
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,0 +1,2 @@
+FROM rabbitmq:3-management
+LABEL maintainer="lixiande <lixiandea@163.com>"

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,2 +1,1 @@
 FROM rabbitmq:3-management
-LABEL maintainer="lixiande <lixiandea@163.com>"

--- a/redis-manage/Dockerfile
+++ b/redis-manage/Dockerfile
@@ -1,3 +1,1 @@
 FROM erikdubbelboer/phpredisadmin
-
-LABEL maintainer="Ving <ving@nivin.cn>"

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,3 +1,1 @@
 FROM redis:5.0
-
-LABEL maintainer="Ving <ving@nivin.cn>"


### PR DESCRIPTION
## 新增消息队列rabbitmq的支持，并带有RABBITMQ_MANAGER 
增加rabbitmq的支持，并添加RABBITM
Q_MANAGER 在15267 端口，账号密码分别为admin和123456
![image](https://user-images.githubusercontent.com/26404619/175826219-42167ed4-0cb3-42bd-b6a3-f6f8e7c7d9c2.png)
